### PR TITLE
Remove redundant review count initialization

### DIFF
--- a/improved_scraper.py
+++ b/improved_scraper.py
@@ -452,7 +452,6 @@ class GoogleMapsScraper:
                 # Try to find review count
                 review_count = 'N/A'
                 # Use CSS where possible and fallback to XPath for text lookup
-                review_count = 'N/A'
                 review_css = [
                     '.F7nice .fontBodySmall',
                     'button[aria-label*="reviews"]',


### PR DESCRIPTION
## Summary
- Remove duplicate `review_count = 'N/A'` initialization in `improved_scraper.py`

## Testing
- `python test/dmv_maps_scraper.py --self-test true`
- `python -m py_compile improved_scraper.py`


------
https://chatgpt.com/codex/tasks/task_e_68bd5dc809708323add5026de4030516