### PR TITLE
Store only 5-digit ZIP codes

### DIFF
--- a/improved_scraper.py
+++ b/improved_scraper.py
@@ -513,7 +513,7 @@ class GoogleMapsScraper:
 
         postal_match = self._postal_re.search(address)
         if postal_match:
-            parts['postal_code'] = postal_match.group(0)
+            parts['postal_code'] = postal_match.group(1)
             # Remove trailing state + ZIP (supports ZIP+4) if present
             street_part = re.sub(r',\s*[A-Z]{2}\s*\d{5}(?:-\d{4})?\s*$', '', address)
             parts['street'] = street_part.strip()

--- a/test/test_parse_address.py
+++ b/test/test_parse_address.py
@@ -1,0 +1,16 @@
+import re
+from improved_scraper import GoogleMapsScraper
+
+
+def make_scraper_without_driver():
+    scraper = GoogleMapsScraper.__new__(GoogleMapsScraper)
+    scraper._postal_re = re.compile(r"\b(\d{5})(?:-\d{4})?\b")
+    return scraper
+
+
+def test_parse_address_truncates_zip_plus4():
+    scraper = make_scraper_without_driver()
+    address = "123 Main St, Washington, DC 20001-1234"
+    parts = scraper.parse_address(address)
+    assert parts["postal_code"] == "20001"
+    assert parts["street"] == "123 Main St, Washington"


### PR DESCRIPTION
## Summary
- capture only the 5-digit portion of ZIP codes in `parse_address`
- add regression test ensuring ZIP+4 values are truncated to five digits

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd6f41485883238f18a440fda0dda1